### PR TITLE
🤖 Corrected type casting mismatch

### DIFF
--- a/android/src/main/java/com/rnlib/adyen/AdyenComponentConfiguration.kt
+++ b/android/src/main/java/com/rnlib/adyen/AdyenComponentConfiguration.kt
@@ -40,7 +40,7 @@ import java.util.Locale
 @SuppressWarnings("TooManyFunctions")
 class AdyenComponentConfiguration : Configuration, Parcelable {
 
-    val availableConfigs: HashMap<String, Configuration>
+    val availableConfigs: Map<String, Configuration>
     val serviceComponentName: ComponentName
     val resultHandlerIntent: Intent
     val amount: Amount
@@ -56,7 +56,7 @@ class AdyenComponentConfiguration : Configuration, Parcelable {
     constructor(
         shopperLocale: Locale,
         environment: Environment,
-        availableConfigs: HashMap<String, Configuration>,
+        availableConfigs: Map<String, Configuration>,
         serviceComponentName: ComponentName,
         resultHandlerIntent: Intent,
         amount: Amount
@@ -69,7 +69,7 @@ class AdyenComponentConfiguration : Configuration, Parcelable {
 
     constructor(parcel: Parcel) : super(parcel) {
         @Suppress("UNCHECKED_CAST")
-        availableConfigs = parcel.readHashMap(Configuration::class.java.classLoader) as HashMap<String, Configuration>
+        availableConfigs = parcel.readHashMap(Configuration::class.java.classLoader) as Map<String, Configuration>
         serviceComponentName = parcel.readParcelable(ComponentName::class.java.classLoader)!!
         resultHandlerIntent = parcel.readParcelable(Intent::class.java.classLoader)!!
         amount = Amount.CREATOR.createFromParcel(parcel)


### PR DESCRIPTION
I corrected the type as I received the following error during build:

`react-native-adyen-payment/android/src/main/java/com/rnlib/adyen/AdyenComponentConfiguration.kt: (80, 23): Java type mismatch expected (Mutable)Map<(raw) Any?, (raw) Any?>! but found kotlin.collections.HashMap<String, Configuration> /* = java.util.HashMap<String, Configuration> */. Use explicit cast
`