### PR TITLE
fix IOS Dropin with multiple credit card

### DIFF
--- a/ios/AdyenPayment.swift
+++ b/ios/AdyenPayment.swift
@@ -174,7 +174,6 @@ class AdyenPayment: RCTEventEmitter {
                 print(stored_py_mthd.type)
                 if(stored_py_mthd.type == "scheme"){
                     storedPaymentMethods.append(stored_py_mthd)
-                    break
                 }
             }
             let dropInComponent = DropInComponent(paymentMethods: PaymentMethods(regular:regularPaymentMethods, stored:storedPaymentMethods),paymentMethodsConfiguration: configuration)


### PR DESCRIPTION
AS a customer with multiple stored Credit Cards, i can view and select an old one 
This PR fix the following issue :  #15

![Simulator Screen Shot - iPhone 11 - 2021-05-25 at 12 19 57](https://user-images.githubusercontent.com/3759537/119481969-9c785880-bd53-11eb-9fcd-acf3ea752332.png)
