### PR TITLE
🐛 Avoid app crash when iDeal is refused on Android

### DIFF
--- a/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
+++ b/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
@@ -546,7 +546,7 @@ class AdyenPaymentModule(private var reactContext : ReactApplicationContext) : R
                 message.put("additionalData", addt_data_obj)
 
                 sendSuccess(message)
-            }else if(rsCode == "Refused" || rsCode == "Error"){
+            }else if((rsCode == "Refused" || rsCode == "Error") && detailsResponse.has("refusalReasonCode")){
                 val err_refusal_code = detailsResponse.getString("refusalReasonCode")
                 val err_code = when(err_refusal_code) {
                     "0" -> "ERROR_GENERAL"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,7 +83,8 @@ class App extends Component<Props> {
             "card_public_key" : CARD_PUBLIC_KEY
           },
           "applepay" : {
-            "apple_pay_merchant_id" : "Your Apple Merchant ID"
+            "apple_pay_merchant_id" : "Your Apple Merchant ID",
+            "apple_pay_label": "Your company name"
           },
           "bcmc":{
             "card_public_key" : CARD_PUBLIC_KEY
@@ -174,7 +175,8 @@ class App extends Component<Props> {
             "card_public_key" : CARD_PUBLIC_KEY
           },
           "applepay" : {
-            "apple_pay_merchant_id" : "Your Apple Merchant ID"
+            "apple_pay_merchant_id" : "Your Apple Merchant ID",
+            "apple_pay_label": "Your company name"
           },
           "bcmc":{
             "card_public_key" : CARD_PUBLIC_KEY

--- a/ios/AdyenPayment.swift
+++ b/ios/AdyenPayment.swift
@@ -148,7 +148,7 @@ class AdyenPayment: RCTEventEmitter {
             guard appleComponent["apple_pay_merchant_id"] != nil else {return}
             do{
                 let amt = NSDecimalNumber(string: String(format: "%.2f", Float(PaymentsData.amount.value) / 100))
-                let applePaySummaryItems = [PKPaymentSummaryItem(label: "Total", amount: amt, type: .final)]
+                let applePaySummaryItems = [PKPaymentSummaryItem(label: (appleComponent["apple_pay_label"] as? String) ?? "Total", amount: amt, type: .final)]
                 let component = try ApplePayComponent(paymentMethod: paymentMethod,payment:Payment(amount: PaymentsData.amount, countryCode: PaymentsData.countryCode),merchantIdentifier: appleComponent["apple_pay_merchant_id"] as! String,summaryItems: applePaySummaryItems)
                 component.delegate = self
                 self.present(component)
@@ -280,7 +280,7 @@ class AdyenPayment: RCTEventEmitter {
             configuration.applePay.merchantIdentifier = appleComponent["apple_pay_merchant_id"] as? String
             // let amt = NSDecimalNumber(string: String(format: "%.2f", Float((PaymentsData.amount.value) / 100)))
             let amt = NSDecimalNumber(string: String(format: "%.2f", Float(PaymentsData.amount.value) / 100))
-            let applePaySummaryItems = [PKPaymentSummaryItem(label: "Total", amount: amt, type: .final)]
+            let applePaySummaryItems = [PKPaymentSummaryItem(label: (appleComponent["apple_pay_label"] as? String) ?? "Total", amount: amt, type: .final)]
             configuration.applePay.summaryItems = applePaySummaryItems
         }
         DispatchQueue.main.async {


### PR DESCRIPTION
Checks that `refusalReasonCode` is given. 
If it's not, the app crashes when using `getString("refusalReasonCode")` without this verification.