### PR TITLE
fix IOS Build error with adyen 3.8.0

### DIFF
--- a/ios/AdyenPayment.swift
+++ b/ios/AdyenPayment.swift
@@ -345,7 +345,7 @@ class AdyenPayment: RCTEventEmitter {
     }
     
     func performPaymentDetails(with data: ActionComponentData) {
-        let request = PaymentDetailsRequest(details: data.details, paymentData: data.paymentData)
+        let request = PaymentDetailsRequest(details: data.details, paymentData: data.paymentData ?? "")
         apiClient.perform(request, completionHandler: paymentResponseHandler)
     }
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-adyen-payment",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-adyen-payment",
   "title": "React Native Adyen Payment",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "React Native Adyen Payment Native Module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
with the Adyen IOS 3.8.0,  the paymentData type can be undefined
